### PR TITLE
more fun with accesspoints

### DIFF
--- a/app.json
+++ b/app.json
@@ -75,6 +75,28 @@
             "max": 0,
             "step": 1,
             "icon": "./assets/rssi.svg"
+        },
+		"ap_current": {
+            "type": "string",
+            "title": {
+                "en": "Current AP",
+                "nl": "Huidig AP",
+                "es": "AP actual"
+            },
+            "getable": true,
+            "setable": false,
+            "icon": "./assets/accesspoint.svg"
+        },
+		"ap_previous": {
+            "type": "string",
+            "title": {
+                "en": "Previous AP",
+                "nl": "Vorig AP",
+                "es": "AP anterior"
+            },
+            "getable": true,
+            "setable": false,
+            "icon": "./assets/accesspoint.svg"
         }
     },
     "flow": {
@@ -95,6 +117,34 @@
                 ],
                 "tokens": [
                     {
+                        "name": "accessPoint",
+                        "type": "string",
+                        "title": {
+							"en": "Current AP",
+							"nl": "Huidig AP",
+							"es": "AP actual"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
+                        "name": "accessPoint_prev",
+                        "type": "string",
+                        "title": {
+							"en": "Previous AP",
+							"nl": "Vorig AP",
+							"es": "AP anterior"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
                         "name": "rssi",
                         "type": "number",
                         "title": {
@@ -151,6 +201,22 @@
                         "type": "device",
                         "filter": "driver_id=wifi-client"
                     }
+				],
+				"tokens": [
+                    {
+                        "name": "accessPoint_prev",
+                        "type": "string",
+                        "title": {
+							"en": "Previous AP",
+							"nl": "Vorig AP",
+							"es": "AP anterior"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    }
                 ]
             },
             {
@@ -169,6 +235,34 @@
                 ],
                 "tokens": [
                     {
+                        "name": "accessPoint",
+                        "type": "string",
+                        "title": {
+							"en": "Current AP",
+							"nl": "Huidig AP",
+							"es": "AP actual"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
+                        "name": "accessPoint_prev",
+                        "type": "string",
+                        "title": {
+							"en": "Previous AP",
+							"nl": "Vorig AP",
+							"es": "AP anterior"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
                         "name": "rssi",
                         "type": "number",
                         "title": {
@@ -219,9 +313,97 @@
                         "name": "accessPoint",
                         "type": "string",
                         "title": {
-                            "en": "AP",
-                            "nl": "AP",
-                            "es": "AP"
+							"en": "Current AP",
+							"nl": "Huidig AP",
+							"es": "AP actual"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
+                        "name": "accessPoint_prev",
+                        "type": "string",
+                        "title": {
+							"en": "Previous AP",
+							"nl": "Vorig AP",
+							"es": "AP anterior"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+                    {
+                        "name": "radio_proto",
+                        "type": "string",
+                        "title": {
+                            "en": "Proto",
+                            "nl": "Proto",
+                            "es": "Proto"
+                        },
+                        "example": "ac"
+                    },
+                    {
+                        "name": "roam_count",
+                        "type": "number",
+                        "title": {
+                            "en": "Roam count",
+                            "nl": "Roam count",
+                            "es": "Roam count"
+                        },
+                        "example": 3
+                    }
+                ]
+            },
+			{
+                "id": "wifi_client_roamed_from_ap",
+                "title": {
+                    "en": "Roams from AP",
+                    "nl": "Zwerft van AP",
+                    "es": "Ruta de AP"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "filter": "driver_id=wifi-client"
+                    },
+                    {
+                        "name": "accessPoint_prev",
+                        "type": "autocomplete",
+                        "placeholder": {
+                            "en": "Accesspoint name",
+                            "nl": "Accesspoint naam",
+                            "es": "Nombre del punto de acceso"
+                        }
+                    }
+                ],
+                "tokens": [
+                    {
+                        "name": "accessPoint",
+                        "type": "string",
+                        "title": {
+							"en": "Current AP",
+							"nl": "Huidig AP",
+							"es": "AP actual"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
+                        "name": "accessPoint_prev",
+                        "type": "string",
+                        "title": {
+							"en": "Previous AP",
+							"nl": "Vorig AP",
+							"es": "AP anterior"
                         },
                         "example": {
                             "en": "ap123",
@@ -279,9 +461,23 @@
                         "name": "accessPoint",
                         "type": "string",
                         "title": {
-                            "en": "AP",
-                            "nl": "AP",
-                            "es": "AP"
+							"en": "Current AP",
+							"nl": "Huidig AP",
+							"es": "AP actual"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
+                        "name": "accessPoint_prev",
+                        "type": "string",
+                        "title": {
+							"en": "Previous AP",
+							"nl": "Vorig AP",
+							"es": "AP anterior"
                         },
                         "example": {
                             "en": "ap123",
@@ -320,6 +516,34 @@
                 },
                 "tokens": [
                     {
+                        "name": "accessPoint",
+                        "type": "string",
+                        "title": {
+							"en": "Current AP",
+							"nl": "Huidig AP",
+							"es": "AP actual"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
+                        "name": "accessPoint_prev",
+                        "type": "string",
+                        "title": {
+							"en": "Previous AP",
+							"nl": "Vorig AP",
+							"es": "AP anterior"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
                         "name": "mac",
                         "type": "string",
                         "title": {
@@ -370,6 +594,34 @@
                 },
                 "tokens": [
                     {
+                        "name": "accessPoint",
+                        "type": "string",
+                        "title": {
+							"en": "Current AP",
+							"nl": "Huidig AP",
+							"es": "AP actual"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
+                        "name": "accessPoint_prev",
+                        "type": "string",
+                        "title": {
+							"en": "Previous AP",
+							"nl": "Vorig AP",
+							"es": "AP anterior"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
                         "name": "mac",
                         "type": "string",
                         "title": {
@@ -418,6 +670,34 @@
                 },
                 "tokens": [
                     {
+                        "name": "accessPoint",
+                        "type": "string",
+                        "title": {
+							"en": "Current AP",
+							"nl": "Huidig AP",
+							"es": "AP actual"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
+                        "name": "accessPoint_prev",
+                        "type": "string",
+                        "title": {
+							"en": "Previous AP",
+							"nl": "Vorig AP",
+							"es": "AP anterior"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
                         "name": "name",
                         "type": "string",
                         "title": {
@@ -488,6 +768,34 @@
                 },
                 "tokens": [
                     {
+                        "name": "accessPoint",
+                        "type": "string",
+                        "title": {
+							"en": "Current AP",
+							"nl": "Huidig AP",
+							"es": "AP actual"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
+                        "name": "accessPoint_prev",
+                        "type": "string",
+                        "title": {
+							"en": "Previous AP",
+							"nl": "Vorig AP",
+							"es": "AP anterior"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
                         "name": "mac",
                         "type": "string",
                         "title": {
@@ -550,6 +858,34 @@
                 },
                 "tokens": [
                     {
+                        "name": "accessPoint",
+                        "type": "string",
+                        "title": {
+							"en": "Current AP",
+							"nl": "Huidig AP",
+							"es": "AP actual"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
+                        "name": "accessPoint_prev",
+                        "type": "string",
+                        "title": {
+							"en": "Previous AP",
+							"nl": "Vorig AP",
+							"es": "AP anterior"
+                        },
+                        "example": {
+                            "en": "ap123",
+                            "nl": "ap123",
+                            "es": "ap123"
+                        }
+                    },
+					{
                         "name": "mac",
                         "type": "string",
                         "title": {
@@ -622,7 +958,8 @@
                 "id": "wifi_client_connected_with_ap",
                 "title": {
                     "en": "!{{C|Disc}}onnected with accesspoint",
-                    "nl": "!{{V|Niet v}}erbonden met accesspoint"
+                    "nl": "!{{V|Niet v}}erbonden met accesspoint",
+					"es": "!{{C|Disc}}onnected with accesspoint"
                 },
                 "args": [
                     {
@@ -685,14 +1022,15 @@
                     },
                     {
                         "id": "sensor",
-                        "capabilities": [ "alarm_connected",  "measure_signal", "measure_rssi" ],
+                        "capabilities": [ "alarm_connected",  "measure_signal", "measure_rssi", "ap_current", "ap_previous" ],
                         "options": {
                             "icons": {
                                 "alarm_connected": "assets/connected.svg",
                                 "measure_signal": "assets/signal.svg",
-                                "measure_rssi": "assets/rssi.svg"
+                                "measure_rssi": "assets/rssi.svg",
+								"ap_current": "assets/accesspoint.svg",
+								"ap_previousr": "assets/accesspoint.svg"
                             },
-
                             "alarm_connected": {
                                 "noblink": false,
                                 "invert": true,
@@ -716,7 +1054,7 @@
                 "small": "drivers/wifi-client/assets/images/small.jpg"
             },
             "class": "sensor",
-            "capabilities": [ "alarm_connected", "measure_rssi",  "measure_signal" ],
+            "capabilities": [ "alarm_connected", "measure_rssi",  "measure_signal", "ap_current", "ap_previous"  ],
             "pair": [
                 {
                     "id": "list_clients",


### PR DESCRIPTION
Hi, because UniFi fixed the AC bug in the new firmware I could use the new flow cards and play around with it. 
Because of that, I came up with some ideas for the app. 

I am not a BIG programmer so maybe you see some things that can be done better. 
I hope you could look into the new features and integrate all or maybe some of it in the next release of the app. 
Especially the new flow card "roams from AP" is good to use. You cannot do the same with "Roams beetween AP" and a Condition Card "Disconnected with accesspoint" if you have more than two access points. With that you could easily check if a smartphone moved from the teen-room to the living room and turn of his/her lights :-)

New features and fixes:
- add current accesspoint and previous accesspoint to the device capatibilities and show it in the homey app
- add new flow trigger "Roams from AP" to detect movements from a specified room to another
- delayed start of client updates. Let homey get the accesspoints first! Without it, flow triggers would run because the AP will be set to null (because it is not yet accessable). Maybe you find a better way. Found that out because the AP are now better visible in the app
- make current AP and previous AP available as token to all flow cards so that you can use it in any way you like.

P.S. sorry for my bad English, I am german. 
P.P.S. I used deepl.com for the translations to spanish and netherlands. Hope they are OK.